### PR TITLE
Change order to updatedAt, update updatedAt if record already exists

### DIFF
--- a/client/src/components/CategoryCard.js
+++ b/client/src/components/CategoryCard.js
@@ -18,7 +18,10 @@ class CategoryCard extends Component {
   }
 
   handleCardClick(ownerId, playlistId, playlistName) {
-    const { playlistActions: { fetchPlaylist }, appActions: { savePlaylistSelection } } = this.props;
+    const {
+      playlistActions: { fetchPlaylist },
+      appActions: { savePlaylistSelection },
+    } = this.props;
 
     fetchPlaylist(ownerId, playlistId);
     savePlaylistSelection('playlist', playlistId, playlistName);

--- a/client/src/containers/DetailContainer.js
+++ b/client/src/containers/DetailContainer.js
@@ -27,7 +27,7 @@ class DetailContainer extends Component {
       playlistObj,
       playlistActions: {
         fetchPlaylistHistory,
-        fetchPlaylist
+        fetchPlaylist,
       } = {},
     } = this.props;
 


### PR DESCRIPTION
 - Updated `PlayHistories` and `SearchHistories` table queries to order by `updatedAt` field for side nav population
 - Updated queries to change the `updatedAt` value when `savePlaylistSelection()` or `saveSearchTerm()` tries to save an existing item