### PR TITLE
Update play history save

### DIFF
--- a/client/src/actions/appActions.js
+++ b/client/src/actions/appActions.js
@@ -15,25 +15,6 @@ import {
 } from './actionTypes';
 
 /**
- * For saving any card clicks to playlist history, for population of DetailView side nav items.
- * Includes album cards, category (playlist) cards etc.
- * No action type necessary, as we don't need to update state for this action. The side nav
- * repopulates itself on every new component mount.
- * TODO: update so that sidenave array state is updated (we are moving this save to play clicks, not ablum/playlist clicks)
- */
-function savePlaylistSelection(playlistType, id, name) { console.log('savePlaylistSelection running... playlistType = ', playlistType, ' id = ', id, ' name = ', name);
-  return (dispatch) => {
-    axios.post(`/app/save/playlist-selection?itemType=${playlistType}&itemId=${id}&itemName=${name}`)
-      .then((response) => {
-        // no-op
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-  };
-}
-
-/**
  * Update (troll) the access token for the spotify player SDK connection requirement
  */
 function fetchAccessToken() {
@@ -258,7 +239,6 @@ function fetchPreviousTrack(deviceId) {
 }
 
 export default {
-  savePlaylistSelection,
   fetchAccessToken,
   receiveDeviceId,
   handlePlayClick,

--- a/client/src/actions/appActions.js
+++ b/client/src/actions/appActions.js
@@ -19,8 +19,9 @@ import {
  * Includes album cards, category (playlist) cards etc.
  * No action type necessary, as we don't need to update state for this action. The side nav
  * repopulates itself on every new component mount.
+ * TODO: update so that sidenave array state is updated (we are moving this save to play clicks, not ablum/playlist clicks)
  */
-function savePlaylistSelection(playlistType, id, name) {
+function savePlaylistSelection(playlistType, id, name) { console.log('savePlaylistSelection running... playlistType = ', playlistType, ' id = ', id, ' name = ', name);
   return (dispatch) => {
     axios.post(`/app/save/playlist-selection?itemType=${playlistType}&itemId=${id}&itemName=${name}`)
       .then((response) => {

--- a/client/src/actions/playlistActions.js
+++ b/client/src/actions/playlistActions.js
@@ -97,7 +97,7 @@ function savePlaylistSelection(playlistType, id, name) {
  * Get user playlist selection history from the database
  * @return {Array} An array of { name, id } objects user previously selected for playing
  */
-function fetchPlaylistHistory() { console.log('fetchPlaylistHistory running...');
+function fetchPlaylistHistory() {
   return (dispatch) => {
     dispatch(requestPlaylistHistory());
 

--- a/client/src/actions/playlistActions.js
+++ b/client/src/actions/playlistActions.js
@@ -77,10 +77,27 @@ function requestPlaylistHistory() {
 }
 
 /**
+ * For saving any card clicks to playlist history, for population of DetailView side nav items.
+ * Includes album cards, category (playlist) cards etc.
+ * When a track is played, this also triggers an immediate update to the DetailContainer side nav
+ */
+function savePlaylistSelection(playlistType, id, name) {
+  return (dispatch) => {
+    axios.post(`/app/save/playlist-selection?itemType=${playlistType}&itemId=${id}&itemName=${name}`)
+      .then((response) => {
+        dispatch(fetchPlaylistHistory()); // repopulate the DetailContainer sidenav listing on play clicks
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  };
+}
+
+/**
  * Get user playlist selection history from the database
  * @return {Array} An array of { name, id } objects user previously selected for playing
  */
-function fetchPlaylistHistory() {
+function fetchPlaylistHistory() { console.log('fetchPlaylistHistory running...');
   return (dispatch) => {
     dispatch(requestPlaylistHistory());
 
@@ -109,6 +126,7 @@ export default {
   fetchAlbum,
   receiveAlbum,
   requestPlaylistHistory,
+  savePlaylistSelection,
   fetchPlaylistHistory,
   receivePlaylistHistory,
 };

--- a/client/src/components/ArtistCard.js
+++ b/client/src/components/ArtistCard.js
@@ -21,17 +21,15 @@ class ArtistCard extends Component {
     };
   }
 
-  handleCardClick(albumId, albumName) {
+  handleCardClick(albumId) {
     const {
       playlistActions: { fetchAlbum },
       searchActions: { saveSearchTerm },
-      appActions: { savePlaylistSelection },
       searchTerm,
       cardType
     } = this.props;
 
     fetchAlbum(albumId);
-    savePlaylistSelection('album', albumId, albumName);
 
     // If user clicked on a card in the search container, save the current searchTerm active state
     if (cardType === 'search' && searchTerm && searchTerm.length) saveSearchTerm(searchTerm.trim());
@@ -43,10 +41,10 @@ class ArtistCard extends Component {
     const { cardArr } = this.props;
 
     const cards = cardArr.map((card, i) => {
-      const { albumId, artist, albumName, imgUrl, releaseDate, albumHref } = card;
+      const { albumId, artist, imgUrl, releaseDate, albumHref } = card;
 
       return (
-        <div key={albumId} className="card card--artist" onClick={() => this.handleCardClick(albumId, albumName)}>
+        <div key={albumId} className="card card--artist" onClick={() => this.handleCardClick(albumId)}>
           <img className="card__img" src={imgUrl} />
           <div className="card__description">{artist}</div>
         </div>
@@ -77,7 +75,6 @@ function mapDispatchToProps(dispatch) {
   return {
     playlistActions: bindActionCreators(playlistActions, dispatch),
     searchActions: bindActionCreators(searchActions, dispatch),
-    appActions: bindActionCreators(appActions, dispatch),
   };
 }
 

--- a/client/src/components/CategoryCard.js
+++ b/client/src/components/CategoryCard.js
@@ -17,14 +17,13 @@ class CategoryCard extends Component {
     this.handleCardClick = this.handleCardClick.bind(this);
   }
 
-  handleCardClick(ownerId, playlistId, playlistName) {
+  handleCardClick(ownerId, playlistId) {
     const {
       playlistActions: { fetchPlaylist },
-      appActions: { savePlaylistSelection },
     } = this.props;
 
     fetchPlaylist(ownerId, playlistId);
-    savePlaylistSelection('playlist', playlistId, playlistName);
+
     this.setState({ redirectToDetailView: true });
   }
 
@@ -32,10 +31,10 @@ class CategoryCard extends Component {
     const { cardArr } = this.props;
 
     const cards = cardArr.map((card, i) => {
-      const { playlistId, playlistName, ownerId, imgUrl, categoryHref } = card;
+      const { playlistId, ownerId, imgUrl, categoryHref } = card;
 
       return (
-        <div key={playlistId} className="card card--category" onClick={() => this.handleCardClick(ownerId, playlistId, playlistName)}>
+        <div key={playlistId} className="card card--category" onClick={() => this.handleCardClick(ownerId, playlistId)}>
           <img className="card__img" src={imgUrl} />
         </div>
       );
@@ -63,7 +62,6 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     playlistActions: bindActionCreators(playlistActions, dispatch),
-    appActions: bindActionCreators(appActions, dispatch),
   };
 }
 

--- a/client/src/containers/DetailContainer.js
+++ b/client/src/containers/DetailContainer.js
@@ -49,14 +49,14 @@ class DetailContainer extends Component {
   }
 
   // Begin new play or resume previously played album or playlist
-  // TODO: clean up all these objects & consolidate some if you can...
+  // TODO: clean up all these objects & consolidate some if you can...and use immutable so it's cleaner?
   handlePlayClick(trackUriArr) {
     const {
       deviceId,
       playerState,
       playedPlayerState,
       playlistObj,
-      appActions: { playSpotifyTrack },
+      appActions: { playSpotifyTrack, savePlaylistSelection },
     } = this.props;
 
     let currentTrackUriArr;
@@ -64,6 +64,11 @@ class DetailContainer extends Component {
     let resumePositionMs;
     let playedAlbumUri;
     let viewedAlbumUri;
+
+    let viewedPlaylistType;
+    let viewedPlaylistName;
+    let viewedPlaylistId;
+    let viewedAlbumId;
 
     // Represents the latest played item; grab the info for resuming play.
     // If no item has been played yet, we use the provided album or playlist uri array
@@ -100,9 +105,18 @@ class DetailContainer extends Component {
     // Represents the most recent album or playlist selection in DetailContainer; the play icon
     // here needs to play the "newly" displayed album if it's different than the last played one
     if (playlistObj && playlistObj.hasOwnProperty('contextUri')) {
-      const { contextUri } = playlistObj;
+      const {
+        contextUri,
+        playlistType,
+        playlistName,
+        playlistId,
+        albumId,
+      } = playlistObj;
 
       viewedAlbumUri = contextUri;
+      viewedPlaylistType = playlistType;
+      viewedPlaylistName = playlistName;
+      viewedPlaylistId = playlistId || albumId;
     }
 
     if (playedAlbumUri !== viewedAlbumUri) {
@@ -111,6 +125,7 @@ class DetailContainer extends Component {
       currentTrackOffset = null;
     }
 
+    savePlaylistSelection(viewedPlaylistType, viewedPlaylistId, viewedPlaylistName);
     playSpotifyTrack(deviceId, currentTrackUriArr, resumePositionMs, currentTrackOffset, playlistObj);
   }
 

--- a/client/src/containers/DetailContainer.js
+++ b/client/src/containers/DetailContainer.js
@@ -56,7 +56,8 @@ class DetailContainer extends Component {
       playerState,
       playedPlayerState,
       playlistObj,
-      appActions: { playSpotifyTrack, savePlaylistSelection },
+      appActions: { playSpotifyTrack },
+      playlistActions: { savePlaylistSelection },
     } = this.props;
 
     let currentTrackUriArr;

--- a/client/src/containers/DetailContainer.js
+++ b/client/src/containers/DetailContainer.js
@@ -116,6 +116,8 @@ class DetailContainer extends Component {
       viewedAlbumUri = contextUri;
       viewedPlaylistType = playlistType;
       viewedPlaylistName = playlistName;
+
+      // Stored these under different names because a playlist can have multiple album ids in tracks
       viewedPlaylistId = playlistId || albumId;
     }
 

--- a/client/src/containers/TrackTable.js
+++ b/client/src/containers/TrackTable.js
@@ -13,13 +13,13 @@ class TrackTable extends Component {
   renderTrackRows() {
     const { trackArr, trackUriArr, playerState } = this.props;
 
-    return trackArr.map((track, i) => {
-      const { trackHref } = track;
+    return trackArr.map((trackObj, i) => {
+      const { trackHref } = trackObj;
 
       return (
         <TrackTableRow
           key={trackHref}
-          track={track}
+          track={trackObj}
           playerState={playerState}
           trackUriArr={trackUriArr}
           trackOffset={i}

--- a/client/src/containers/TrackTableRow.js
+++ b/client/src/containers/TrackTableRow.js
@@ -17,13 +17,16 @@ class TrackTableRow extends Component {
     const {
       deviceId,
       playerState,
-      playlistObj,
       trackUriArr,
       trackOffset,
-      appActions: { playSpotifyTrack }
+      playlistObj,
+      appActions: { playSpotifyTrack, savePlaylistSelection },
     } = this.props;
 
     let resumePositionMs;
+    let viewedPlaylistType;
+    let viewedPlaylistName;
+    let viewedPlaylistId;
 
     // If we have a previously saved player state, extract uri & determine if we "resume" play
     if (playerState && playerState.hasOwnProperty('track_window')) {
@@ -37,6 +40,20 @@ class TrackTableRow extends Component {
       }
     }
 
+    if (playlistObj && playlistObj.hasOwnProperty('playlistType')) {
+      const {
+        playlistId,
+        albumId,
+        playlistName,
+        playlistType,
+      } = playlistObj;
+
+      viewedPlaylistId = playlistId || albumId;
+      viewedPlaylistName = playlistName;
+      viewedPlaylistType = playlistType;
+    }
+
+    savePlaylistSelection(viewedPlaylistType, viewedPlaylistId, viewedPlaylistName);
     playSpotifyTrack(deviceId, trackUriArr, resumePositionMs, trackOffset, playlistObj);
   }
 

--- a/client/src/containers/TrackTableRow.js
+++ b/client/src/containers/TrackTableRow.js
@@ -3,6 +3,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import appActions from '../actions/appActions';
+import playlistActions from '../actions/playlistActions';
 import PlayIconContainer from './PlayIconContainer';
 
 class TrackTableRow extends Component {
@@ -20,7 +21,8 @@ class TrackTableRow extends Component {
       trackUriArr,
       trackOffset,
       playlistObj,
-      appActions: { playSpotifyTrack, savePlaylistSelection },
+      appActions: { playSpotifyTrack },
+      playlistActions: { fetchPlaylistHistory, savePlaylistSelection },
     } = this.props;
 
     let resumePositionMs;
@@ -55,6 +57,7 @@ class TrackTableRow extends Component {
 
     savePlaylistSelection(viewedPlaylistType, viewedPlaylistId, viewedPlaylistName);
     playSpotifyTrack(deviceId, trackUriArr, resumePositionMs, trackOffset, playlistObj);
+    fetchPlaylistHistory(); //
   }
 
   handlePauseClick() {
@@ -110,6 +113,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     appActions: bindActionCreators(appActions, dispatch),
+    playlistActions: bindActionCreators(playlistActions, dispatch),
   };
 }
 

--- a/client/src/reducers/playlistReducer.js
+++ b/client/src/reducers/playlistReducer.js
@@ -34,7 +34,7 @@ export default function playlistReducer(state = initialState, action) {
         playlistObj,
       };
       return newState;
-    case RECEIVE_PLAYLIST_HISTORY: console.log('RECEIVE_PLAYLIST_HISTORY reducer running...')
+    case RECEIVE_PLAYLIST_HISTORY:
       newState = {
         ...state,
         playlistHistoryArr,

--- a/client/src/reducers/playlistReducer.js
+++ b/client/src/reducers/playlistReducer.js
@@ -34,7 +34,7 @@ export default function playlistReducer(state = initialState, action) {
         playlistObj,
       };
       return newState;
-    case RECEIVE_PLAYLIST_HISTORY:
+    case RECEIVE_PLAYLIST_HISTORY: console.log('RECEIVE_PLAYLIST_HISTORY reducer running...')
       newState = {
         ...state,
         playlistHistoryArr,

--- a/controllers/albumController.js
+++ b/controllers/albumController.js
@@ -26,6 +26,8 @@ function formatPlaylistObj(body) {
     uri: contextUri, // uri context for player SDK i.e. "spotify:album", "spotify:user:spotify:playlist" etc
   } = parsedResponse;
 
+  // Used for recording play click history
+  const playlistType = 'album';
   let trackUriArr = [];
 
   const trackArr = tracks.reduce((returnArr, track) => {
@@ -41,6 +43,9 @@ function formatPlaylistObj(body) {
     const formattedDuration = formatTrackDuration(duration);
 
     const trackObj = {
+      albumId,
+      playlistType,
+      playlistName,
       trackId,
       trackName,
       trackNumber,
@@ -59,6 +64,8 @@ function formatPlaylistObj(body) {
   }, []);
 
   const playlistObj = {
+    albumId,
+    playlistType,
     playlistName,
     trackArr,
     trackUriArr,

--- a/controllers/playlistController.js
+++ b/controllers/playlistController.js
@@ -18,6 +18,7 @@ function formatPlaylistObj(body) {
 
   const {
     images,
+    id: playlistId,
     description: playlistDescription,
     followers: { total: playlistFollowers },
     name: playlistName,
@@ -25,6 +26,8 @@ function formatPlaylistObj(body) {
     uri: contextUri,
   } = parsedResponse;
 
+  // Used for recording play click history
+  const playlistType = 'playlist';
   let trackUriArr = [];
 
   // Put array objects in usable form
@@ -43,6 +46,9 @@ function formatPlaylistObj(body) {
     const formattedDuration = formatTrackDuration(duration);
 
     const trackObj = {
+      playlistId,
+      playlistType,
+      playlistName,
       trackId,
       trackName,
       trackNumber,
@@ -62,6 +68,8 @@ function formatPlaylistObj(body) {
   }, []);
 
   const playlistObj = {
+    playlistId,
+    playlistType,
     playlistName,
     playlistDescription,
     playlistFollowers,


### PR DESCRIPTION
 - Remove `savePlaylistSelection()` from ArtistCard and CategoryCard clicks and move to any track play action
 - Move `savePlaylistSelection()` from appActions to playlistActions
 - Dispatch `fetchPlaylistHistory()` on every `savePlaylistSelection()` action so that DetailContainer re-renders on every play action